### PR TITLE
(CPR-583) Add `puppet-docker local-lint` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ puppet-docker help
 Usage:
   puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache]
   puppet-docker lint [DIRECTORY] [--dockerfile=<dockerfile>]
+  puppet-docker local-lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker pull [IMAGE] [--repository=<repo>]
   puppet-docker push [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>]
   puppet-docker rev-labels [DIRECTORY] [--dockerfile=<dockerfile>] [--namespace=<namespace>]
@@ -47,6 +48,10 @@ Run [hadolint](https://github.com/hadolint/hadolint) on the dockerfile in DIRECT
 * [DL3018](https://github.com/hadolint/hadolint/wiki/DL3018) - Pin versions in apk install
 * [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000) - MAINTAINER is deprecated
 * [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001) - Don't use both wget and curl
+
+### `puppet-docker local-lint`
+
+Run [hadolint](https://github.com/hadolint/hadolint) on the dockerfile in DIRECTORY. The lint task runs using a locally installed `hadolint` executable with the same rule exclusions as `puppet-docker lint`.
 
 ### `puppet-docker pull`
 

--- a/bin/puppet-docker
+++ b/bin/puppet-docker
@@ -9,6 +9,7 @@ Utilities for building and releasing Puppet docker images.
 Usage:
   puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache]
   puppet-docker lint [DIRECTORY] [--dockerfile=<dockerfile>]
+  puppet-docker local-lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker pull [IMAGE] [--repository=<repo>]
   puppet-docker push [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>]
   puppet-docker rev-labels [DIRECTORY] [--dockerfile=<dockerfile>] [--namespace=<namespace>]
@@ -71,6 +72,8 @@ begin
       command_runner.build(no_cache: options['--no-cache'])
     elsif options['lint']
       command_runner.lint
+    elsif options['local-lint']
+      command_runner.local_lint
     elsif options['push']
       command_runner.push
     elsif options['rev-labels']

--- a/lib/puppet_docker_tools/utilities.rb
+++ b/lib/puppet_docker_tools/utilities.rb
@@ -126,6 +126,23 @@ class PuppetDockerTools
       end
     end
 
+    # Generate the hadolint command that should be run. Hadolint is a
+    # linter for dockerfiles that also validates inline bash with shellcheck.
+    # For more info, see the github repo (https://github.com/hadolint/hadolint)
+    #
+    # @param file Dockerfile to lint, defaults to stdin
+    def get_hadolint_command(file = '-')
+      ignore_rules = [
+        'DL3008',
+        'DL3018',
+        'DL4000',
+        'DL4001',
+      ]
+      ignore_string = ignore_rules.map { |x| "--ignore #{x}" }.join(' ')
+
+      "hadolint #{ignore_string} #{file}"
+    end
+
     # Get a value from a Dockerfile
     #
     # @param key The key to read from the Dockerfile, e.g. 'from'

--- a/spec/lib/puppet_docker_tools/runner_spec.rb
+++ b/spec/lib/puppet_docker_tools/runner_spec.rb
@@ -86,6 +86,13 @@ describe PuppetDockerTools::Runner do
     end
   end
 
+  describe '#local_lint' do
+    it "should fail with logs if linting fails" do
+      allow(Open3).to receive(:capture2e).with(PuppetDockerTools::Utilities.get_hadolint_command('/tmp/test-image/Dockerfile')).and_return('container logs', 1)
+      expect { runner.local_lint }.to raise_error(RuntimeError, /container logs/)
+    end
+  end
+
   describe '#push' do
     it 'should fail if no version is set' do
       expect(PuppetDockerTools::Utilities).to receive(:get_value_from_label).and_return(nil)

--- a/spec/lib/puppet_docker_tools/utilities_spec.rb
+++ b/spec/lib/puppet_docker_tools/utilities_spec.rb
@@ -195,4 +195,13 @@ HERE
     end
   end
 
+  describe '#get_hadolint_command' do
+    it 'generates a commmand with a dockerfile' do
+      expect(PuppetDockerTools::Utilities.get_hadolint_command('test/Dockerfile')).to eq('hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001 test/Dockerfile')
+    end
+
+    it 'defaults to generating a command that reads from stdin' do
+      expect(PuppetDockerTools::Utilities.get_hadolint_command).to eq('hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001 -')
+    end
+  end
 end


### PR DESCRIPTION
This allows you to run hadolint using a local binary rather than running
it via the hadolint docker container. This is useful in instances where
spinning up a docker container with files mounting into it is
complicated, such as running on a docker image in ci.