### PR TITLE
(maint) Add shared example

### DIFF
--- a/spec/support/examples/running_container.rb
+++ b/spec/support/examples/running_container.rb
@@ -1,0 +1,11 @@
+shared_examples "a running container" do |command, exit_status|
+  it "should run #{command} with exit status #{exit_status}" do
+    container = Docker::Container.create('Image' => @image.id, 'Cmd' => command)
+    container.start
+    container.wait
+    exit_status = container.json['State']['ExitCode']
+    expect(exit_status).to eq(exit_status)
+    container.kill
+    container.delete(force: true)
+  end
+end


### PR DESCRIPTION
When running in CI, especially for containers that are very quick to
start up, it can be helpful to manage container lifecycle directly in
the example. This sets up a shared example that starts a container built
from the current directory, runs a command, checks the exit status, and
destroys the container.

The shared context should still work for many cases, but if you see
failures along the lines of 'container is not running' the shared
example can help you work through that.