### PR TITLE
(maint) Add support for buildargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ Output the `version` label for the dockerfile contained in DIRECTORY.
 
 Update the base images. Any number of tags to update can be passed, or by default it will pull the latest version of: ['ubuntu:16.04', 'centos:7', 'alpine:3.4', 'debian:9', 'postgres:9.6.8']
 
+## Items available to Dockerfiles
+
+There are some common variables passed to builds that you can take advantage of in your Dockerfiles.
+
+### `ARG`s
+
+* `vcs_ref`: set to `git rev-parse HEAD`
+* `build_date`: set to ruby's `Time.now.utc.iso8601`
+
 ## Issues
 
 File issues in the [Community Package Repository (CPR) project](https://tickets.puppet.com/browse/CPR) with the 'Container' component.

--- a/lib/puppet_docker_tools/runner.rb
+++ b/lib/puppet_docker_tools/runner.rb
@@ -1,5 +1,6 @@
 require 'date'
 require 'docker'
+require 'json'
 require 'rspec/core'
 require 'time'
 require 'puppet_docker_tools/utilities'
@@ -29,8 +30,14 @@ class PuppetDockerTools
       path = "#{repository}/#{image_name}"
       puts "Building #{path}:latest"
 
+      build_args = {
+        'vcs_ref' => PuppetDockerTools::Utilities.current_git_sha(directory),
+        'build_date' => Time.now.utc.iso8601
+      }
+
       # 't' in the build_options sets the tag for the image we're building
-      build_options = { 't' => "#{path}:latest", 'dockerfile' => dockerfile }
+      build_options = { 't' => "#{path}:latest", 'dockerfile' => dockerfile, 'buildargs' => "#{build_args.to_json}"}
+
       if no_cache
         puts "Ignoring cache for #{path}"
         build_options['nocache'] = true

--- a/lib/puppet_docker_tools/runner.rb
+++ b/lib/puppet_docker_tools/runner.rb
@@ -40,8 +40,7 @@ class PuppetDockerTools
       if version
         puts "Building #{path}:#{version}"
 
-        # 't' in the build_options sets the tag for the image we're building
-        build_options = { 't' => "#{path}:#{version}", 'dockerfile' => dockerfile }
+        build_options['t'] = "#{path}:#{version}"
         Docker::Image.build_from_dir(directory, build_options)
       end
     end


### PR DESCRIPTION
We label the containers with build date and vcs ref, but those are currently hardcoded in the Dockerfiles. Adding these as buildargs allow the dockerfiles to be updated to set these at buildtime instead.