### PR TITLE
(CPR-584) Add support for passing in version at container build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ You also need to have docker installed and running. See [these docs](https://doc
 
 ```
 $ puppet-docker help
+Utilities for building and releasing Puppet docker images.
+
 Usage:
-  puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache]
+  puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache] [--version=<version] [--build-arg=<buildarg> ...]
   puppet-docker lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker local-lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker pull [IMAGE] [--repository=<repo>]
@@ -35,6 +37,9 @@ Options:
   --no-cache                 Disable use of layer cache when building this image. Defaults to using the cache.
   --namespace=<namespace>    Namespace for labels on the container [default: org.label-schema]
   --dockerfile=<dockerfile>  File name for your dockerfile [default: Dockerfile]
+  --version=<version>        Version to build. This field will be used to determine the label and will be passed as the version build arg.
+                             **NOTE** `--build-arg version='<version>'` overrides `--version <version>`
+  --build-arg=<buildarg>     Build arg to pass to container build, can be passed multiple times.
 ```
 
 ### `puppet-docker build`

--- a/bin/puppet-docker
+++ b/bin/puppet-docker
@@ -7,7 +7,7 @@ doc = <<DOC
 Utilities for building and releasing Puppet docker images.
 
 Usage:
-  puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache]
+  puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache] [--version=<version] [--build-arg=<buildarg> ...]
   puppet-docker lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker local-lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker pull [IMAGE] [--repository=<repo>]
@@ -29,6 +29,9 @@ Options:
   --no-cache                 Disable use of layer cache when building this image. Defaults to using the cache.
   --namespace=<namespace>    Namespace for labels on the container [default: org.label-schema]
   --dockerfile=<dockerfile>  File name for your dockerfile [default: Dockerfile]
+  --version=<version>        Version to build. This field will be used to determine the label and will be passed as the version build arg.
+                             **NOTE** `--build-arg version='<version>'` overrides `--version <version>`
+  --build-arg=<buildarg>     Build arg to pass to container build, can be passed multiple times.
 DOC
 
 begin
@@ -44,6 +47,8 @@ defaults = {
   '--namespace'  => 'org.label-schema',
   '--repository' => 'puppet',
   '--dockerfile' => 'Dockerfile',
+  '--version'    => nil,
+  '--build-arg'  => [],
 }
 
 options.merge!(defaults) do |key, option, default|
@@ -69,7 +74,7 @@ begin
     command_runner = PuppetDockerTools::Runner.new(directory: options['DIRECTORY'], repository: options['--repository'], namespace: options['--namespace'], dockerfile: options['--dockerfile'])
 
     if options['build']
-      command_runner.build(no_cache: options['--no-cache'])
+      command_runner.build(no_cache: options['--no-cache'], version: options['--version'], build_args: options['--build-arg'])
     elsif options['lint']
       command_runner.lint
     elsif options['local-lint']

--- a/lib/puppet_docker_tools/utilities.rb
+++ b/lib/puppet_docker_tools/utilities.rb
@@ -26,6 +26,25 @@ class PuppetDockerTools
       end
     end
 
+    # parse build args into a hash for easier manipulation
+    #
+    # @param build_args array of build_args with each entry in the format 'arg=value'
+    def parse_build_args(build_args)
+      args_hash = {}
+
+      build_args.each do |arg|
+        fields = arg.split('=')
+        key = fields.first
+        # get rid of the key from the fields so we can get the value
+        fields.shift
+        # join the remaining fields with '=' in case the value had '=' in it
+        value = fields.join('=')
+        args_hash[key] = value
+      end
+
+      args_hash
+    end
+
     # Get a value from the labels on a docker image
     #
     # @param image The docker image you want to get a value from, e.g. 'puppet/puppetserver'

--- a/spec/lib/puppet_docker_tools/utilities_spec.rb
+++ b/spec/lib/puppet_docker_tools/utilities_spec.rb
@@ -204,4 +204,22 @@ HERE
       expect(PuppetDockerTools::Utilities.get_hadolint_command).to eq('hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001 -')
     end
   end
+
+  describe '#parse_build_args' do
+    let(:build_args) {
+      [
+        'foo=bar',
+        'test=a=string=with==equals'
+      ]
+    }
+    let(:build_args_hash) {
+      {
+        'foo' => 'bar',
+        'test' => 'a=string=with==equals'
+      }
+    }
+    it 'converts the array to a hash' do
+      expect(PuppetDockerTools::Utilities.parse_build_args(build_args)).to eq(build_args_hash)
+    end
+  end
 end


### PR DESCRIPTION
This change adds support for passing in arbitrary `--build-arg`s when
building the container, and also adds support for passing `--version`
explicitly to the build.