### PR TITLE
(CPR-590) Add `--no-latest` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ $ puppet-docker help
 Utilities for building and releasing Puppet docker images.
 
 Usage:
-  puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache] [--version=<version] [--build-arg=<buildarg> ...]
+  puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache] [--version=<version] [--build-arg=<buildarg> ...] [--no-latest]
   puppet-docker lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker local-lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker pull [IMAGE] [--repository=<repo>]
-  puppet-docker push [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>]
+  puppet-docker push [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-latest]
   puppet-docker rev-labels [DIRECTORY] [--dockerfile=<dockerfile>] [--namespace=<namespace>]
   puppet-docker spec [DIRECTORY]
   puppet-docker test [DIRECTORY] [--dockerfile=<dockerfile>]
@@ -40,6 +40,8 @@ Options:
   --version=<version>        Version to build. This field will be used to determine the label and will be passed as the version build arg.
                              **NOTE** `--build-arg version='<version>'` overrides `--version <version>`
   --build-arg=<buildarg>     Build arg to pass to container build, can be passed multiple times.
+  --no-latest                Do not include the 'latest' tag when building and shipping images. By default, the 'latest' tag is built and
+                             shipped with the versioned tag.
 ```
 
 ### `puppet-docker build`

--- a/bin/puppet-docker
+++ b/bin/puppet-docker
@@ -7,11 +7,11 @@ doc = <<DOC
 Utilities for building and releasing Puppet docker images.
 
 Usage:
-  puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache] [--version=<version] [--build-arg=<buildarg> ...]
+  puppet-docker build [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-cache] [--version=<version] [--build-arg=<buildarg> ...] [--no-latest]
   puppet-docker lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker local-lint [DIRECTORY] [--dockerfile=<dockerfile>]
   puppet-docker pull [IMAGE] [--repository=<repo>]
-  puppet-docker push [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>]
+  puppet-docker push [DIRECTORY] [--dockerfile=<dockerfile>] [--repository=<repo>] [--namespace=<namespace>] [--no-latest]
   puppet-docker rev-labels [DIRECTORY] [--dockerfile=<dockerfile>] [--namespace=<namespace>]
   puppet-docker spec [DIRECTORY]
   puppet-docker test [DIRECTORY] [--dockerfile=<dockerfile>]
@@ -32,6 +32,8 @@ Options:
   --version=<version>        Version to build. This field will be used to determine the label and will be passed as the version build arg.
                              **NOTE** `--build-arg version='<version>'` overrides `--version <version>`
   --build-arg=<buildarg>     Build arg to pass to container build, can be passed multiple times.
+  --no-latest                Do not include the 'latest' tag when building and shipping images. By default, the 'latest' tag is built and
+                             shipped with the versioned tag.
 DOC
 
 begin
@@ -49,6 +51,7 @@ defaults = {
   '--dockerfile' => 'Dockerfile',
   '--version'    => nil,
   '--build-arg'  => [],
+  '--no-latest'  => false,
 }
 
 options.merge!(defaults) do |key, option, default|
@@ -73,14 +76,19 @@ begin
   else
     command_runner = PuppetDockerTools::Runner.new(directory: options['DIRECTORY'], repository: options['--repository'], namespace: options['--namespace'], dockerfile: options['--dockerfile'])
 
+    latest = true
+    if options['--no-latest']
+      latest = false
+    end
+
     if options['build']
-      command_runner.build(no_cache: options['--no-cache'], version: options['--version'], build_args: options['--build-arg'])
+      command_runner.build(no_cache: options['--no-cache'], version: options['--version'], build_args: options['--build-arg'], latest: latest)
     elsif options['lint']
       command_runner.lint
     elsif options['local-lint']
       command_runner.local_lint
     elsif options['push']
-      command_runner.push
+      command_runner.push(latest: latest)
     elsif options['rev-labels']
       command_runner.rev_labels
     elsif options['spec']

--- a/spec/lib/puppet_docker_tools/runner_spec.rb
+++ b/spec/lib/puppet_docker_tools/runner_spec.rb
@@ -38,6 +38,12 @@ describe PuppetDockerTools::Runner do
       runner.build
     end
 
+    it 'does not build a latest tag if latest is set to false' do
+      expect(PuppetDockerTools::Utilities).to receive(:get_value_from_env).with('version', namespace: runner.namespace, directory: runner.directory, dockerfile: runner.dockerfile).and_return('1.2.3')
+      expect(Docker::Image).to receive(:build_from_dir).with(runner.directory, { 't' => 'test/test-image:1.2.3', 'dockerfile' => runner.dockerfile, 'buildargs' => buildargs }).and_return(image)
+      runner.build(latest: false)
+    end
+
     it 'ignores the cache when that parameter is set' do
       expect(PuppetDockerTools::Utilities).to receive(:get_value_from_env).with('version', namespace: runner.namespace, directory: runner.directory, dockerfile: runner.dockerfile).and_return(nil)
       expect(Docker::Image).to receive(:build_from_dir).with(runner.directory, { 't' => 'test/test-image:latest', 'nocache' => true, 'dockerfile' => runner.dockerfile, 'buildargs' => buildargs }).and_return(image)
@@ -140,6 +146,12 @@ describe PuppetDockerTools::Runner do
       expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:1.2.3').and_return([0, nil])
       expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:latest').and_return([0, nil])
       runner.push
+    end
+
+    it 'should not push the latest tag if latest is set to false' do
+      expect(PuppetDockerTools::Utilities).to receive(:get_value_from_label).with('test/test-image', value: 'version', namespace: runner.namespace).and_return('1.2.3')
+      expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:1.2.3').and_return([0, nil])
+      runner.push(latest: false)
     end
   end
 


### PR DESCRIPTION
This can be used in build and push operations to disable the 'latest'
tag. Intended use case for this is building off of multiple
branches/version streams but only wanting the 'latest' tag for one of
those streams.