### PR TITLE
(maint) Improve get_value_from_env

### DIFF
--- a/lib/puppet_docker_tools/utilities.rb
+++ b/lib/puppet_docker_tools/utilities.rb
@@ -234,9 +234,11 @@ class PuppetDockerTools
         fail "File #{file} doesn't exist!" unless File.exist? file
         dockerfile_contents = File.read("#{file}")
       end
+      variable_clone = String.new(variable)
       # get rid of the leading $ for the variable
-      variable[0] = ''
-      dockerfile_contents[/#{variable}=([$"'a-zA-Z0-9\.]+)/, 1]
+      variable_clone[0] = ''
+
+      dockerfile_contents[/#{variable_clone}=([$"'a-zA-Z0-9\.]+)/, 1]
     end
     private :get_value_from_variable
   end

--- a/lib/puppet_docker_tools/utilities.rb
+++ b/lib/puppet_docker_tools/utilities.rb
@@ -238,7 +238,7 @@ class PuppetDockerTools
       # get rid of the leading $ for the variable
       variable_clone[0] = ''
 
-      dockerfile_contents[/#{variable_clone}=([$"'a-zA-Z0-9\.]+)/, 1]
+      dockerfile_contents[/#{variable_clone}=([^\s]+)/, 1]
     end
     private :get_value_from_variable
   end

--- a/lib/puppet_docker_tools/utilities.rb
+++ b/lib/puppet_docker_tools/utilities.rb
@@ -98,7 +98,7 @@ class PuppetDockerTools
       value = text.scan(/#{Regexp.escape(namespace)}\.(.+)=(.+) \\?/).to_h[label]
       # expand out environment variables
       # This supports either label=$variable or label="$variable"
-      if value.start_with?('$') || value.start_with?('"$')
+      while ! value.nil? && (value.start_with?('$') || value.start_with?('"$'))
         # if variable is quoted, get rid of leading and trailing quotes
         value.gsub!(/\A"|"\Z/, '')
         value = get_value_from_variable(value, directory: directory, dockerfile: dockerfile, dockerfile_contents: text)
@@ -236,7 +236,7 @@ class PuppetDockerTools
       end
       # get rid of the leading $ for the variable
       variable[0] = ''
-      dockerfile_contents[/#{variable}=(["a-zA-Z0-9\.]+)/, 1]
+      dockerfile_contents[/#{variable}=([$"'a-zA-Z0-9\.]+)/, 1]
     end
     private :get_value_from_variable
   end


### PR DESCRIPTION
Right now it will try get_value_from_variable once, then it will start
looking in the upstream dockerfile. As we start adding ARGs, we may end
up with variables set to other variables defined in the same dockerfile.
We'll now call get_value_from_variable until we find a variable that
isn't defined in this dockerfile before trying the upstream.