### PR TITLE
(maint) Get rid of dockerhub references

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Arguments:
   TAG        Pull latest versions of images at TAG. Defaults to ['ubuntu:16.04', 'centos:7', 'alpine:3.4', 'debian:9', 'postgres:9.6.8']
 
 Options:
-  --repository=<repo>        Dockerhub repository containing the image [default: puppet]
+  --repository=<repo>        Docker repository containing the image [default: puppet]
   --no-cache                 Disable use of layer cache when building this image. Defaults to using the cache.
   --namespace=<namespace>    Namespace for labels on the container [default: org.label-schema]
   --dockerfile=<dockerfile>  File name for your dockerfile [default: Dockerfile]
@@ -66,7 +66,7 @@ Pull the specified image, i.e. 'puppet/puppetserver'. *NOTE*: If you don't inclu
 
 ### `puppet-docker push`
 
-Push images built from the dockerfile in DIRECTORY to hub.docker.com. This task will fail if you do not have a version specified in your dockerfile. It will push both a versioned and a 'latest' tagged image.
+Push images built from the dockerfile in DIRECTORY to <repo>. This task will fail if you do not have a version specified in your dockerfile. It will push both a versioned and a 'latest' tagged image.
 
 ### `puppet-docker rev-labels`
 

--- a/bin/puppet-docker
+++ b/bin/puppet-docker
@@ -25,7 +25,7 @@ Arguments:
   TAG        Pull latest versions of images at TAG. Defaults to ['ubuntu:16.04', 'centos:7', 'alpine:3.4', 'debian:9', 'postgres:9.6.8']
 
 Options:
-  --repository=<repo>        Dockerhub repository containing the image [default: puppet]
+  --repository=<repo>        Docker repository containing the image [default: puppet]
   --no-cache                 Disable use of layer cache when building this image. Defaults to using the cache.
   --namespace=<namespace>    Namespace for labels on the container [default: org.label-schema]
   --dockerfile=<dockerfile>  File name for your dockerfile [default: Dockerfile]

--- a/lib/puppet_docker_tools/runner.rb
+++ b/lib/puppet_docker_tools/runner.rb
@@ -114,7 +114,7 @@ class PuppetDockerTools
       fail output unless status == 0
     end
 
-    # Push an image to hub.docker.com
+    # Push an image to $repository
     #
     # @param latest Whether or not to push the latest tag along with the
     #        versioned image build.
@@ -128,17 +128,17 @@ class PuppetDockerTools
         fail "No version specified in #{dockerfile} for #{path}"
       end
 
-      puts "Pushing #{path}:#{version} to Docker Hub"
-      exitstatus, _ = PuppetDockerTools::Utilities.push_to_dockerhub("#{path}:#{version}")
+      puts "Pushing #{path}:#{version}"
+      exitstatus, _ = PuppetDockerTools::Utilities.push_to_docker_repo("#{path}:#{version}")
       unless exitstatus == 0
-        fail "Pushing #{path}:#{version} to dockerhub failed!"
+        fail "Pushing #{path}:#{version} failed!"
       end
 
       if latest
-        puts "Pushing #{path}:latest to Docker Hub"
-        exitstatus, _ = PuppetDockerTools::Utilities.push_to_dockerhub("#{path}:latest")
+        puts "Pushing #{path}:latest"
+        exitstatus, _ = PuppetDockerTools::Utilities.push_to_docker_repo("#{path}:latest")
         unless exitstatus == 0
-          fail "Pushing #{path}:latest to dockerhub failed!"
+          fail "Pushing #{path}:latest failed!"
         end
       end
     end

--- a/lib/puppet_docker_tools/utilities.rb
+++ b/lib/puppet_docker_tools/utilities.rb
@@ -5,14 +5,16 @@ class PuppetDockerTools
   module Utilities
     module_function
 
-    # Push an image to hub.docker.com
+    # Push an image to a docker repository
     #
     # @param image_name The image to push, including the tag e.g., puppet/puppetserver:latest
+    #        If pushing to a private repo, the image name should include the repo endpoint,
+    #        like my-docker-repo.internal.net/puppet/puppetserver:latest
     # @param stream_output Whether or not to stream output as it comes in, defaults to true
     # @return Returns an array containing the integer exitstatus of the push
     #         command and a string containing the combined stdout and stderr
     #         from the push
-    def push_to_dockerhub(image_name, stream_output=true)
+    def push_to_docker_repo(image_name, stream_output=true)
       Open3.popen2e("docker push #{image_name}") do |stdin, output_stream, wait_thread|
         output=''
         while line = output_stream.gets

--- a/spec/lib/puppet_docker_tools/runner_spec.rb
+++ b/spec/lib/puppet_docker_tools/runner_spec.rb
@@ -147,27 +147,27 @@ describe PuppetDockerTools::Runner do
 
     it 'should raise an error if something bad happens pushing the versioned tag' do
       expect(PuppetDockerTools::Utilities).to receive(:get_value_from_label).with('test/test-image', value: 'version', namespace: runner.namespace).and_return('1.2.3')
-      expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:1.2.3').and_return([1, nil])
-      expect { runner.push }.to raise_error(RuntimeError, /1.2.3 to dockerhub/i)
+      expect(PuppetDockerTools::Utilities).to receive(:push_to_docker_repo).with('test/test-image:1.2.3').and_return([1, nil])
+      expect { runner.push }.to raise_error(RuntimeError, /1.2.3 failed/i)
     end
 
     it 'should raise an error if something bad happens pushing the latest tag' do
       expect(PuppetDockerTools::Utilities).to receive(:get_value_from_label).with('test/test-image', value: 'version', namespace: runner.namespace).and_return('1.2.3')
-      expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:1.2.3').and_return([0, nil])
-      expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:latest').and_return([1, nil])
-      expect { runner.push }.to raise_error(RuntimeError, /latest to dockerhub/i)
+      expect(PuppetDockerTools::Utilities).to receive(:push_to_docker_repo).with('test/test-image:1.2.3').and_return([0, nil])
+      expect(PuppetDockerTools::Utilities).to receive(:push_to_docker_repo).with('test/test-image:latest').and_return([1, nil])
+      expect { runner.push }.to raise_error(RuntimeError, /latest failed/i)
     end
 
     it 'should push the versioned and latest tags if nothing goes wrong' do
       expect(PuppetDockerTools::Utilities).to receive(:get_value_from_label).with('test/test-image', value: 'version', namespace: runner.namespace).and_return('1.2.3')
-      expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:1.2.3').and_return([0, nil])
-      expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:latest').and_return([0, nil])
+      expect(PuppetDockerTools::Utilities).to receive(:push_to_docker_repo).with('test/test-image:1.2.3').and_return([0, nil])
+      expect(PuppetDockerTools::Utilities).to receive(:push_to_docker_repo).with('test/test-image:latest').and_return([0, nil])
       runner.push
     end
 
     it 'should not push the latest tag if latest is set to false' do
       expect(PuppetDockerTools::Utilities).to receive(:get_value_from_label).with('test/test-image', value: 'version', namespace: runner.namespace).and_return('1.2.3')
-      expect(PuppetDockerTools::Utilities).to receive(:push_to_dockerhub).with('test/test-image:1.2.3').and_return([0, nil])
+      expect(PuppetDockerTools::Utilities).to receive(:push_to_docker_repo).with('test/test-image:1.2.3').and_return([0, nil])
       runner.push(latest: false)
     end
   end


### PR DESCRIPTION
If you don't specify a different repo in your tag, images will get
pushed to dockerhub, but those messages are confusing if you're instead
pushing to an internal repo.